### PR TITLE
Address `golangci-lint` findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+---
+version: "2"
+linters:
+  default: standard
+  exclusions:
+    rules:
+    - path: .+_test\.go
+      text: "Error return value of `fmt.Fprintf` is not checked"
+      linters:
+      - errcheck

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/pflag"
@@ -44,6 +45,11 @@ func (t *tag) Set(s string) (err error) {
 
 func (t *tag) Type() string {
 	return "image tag"
+}
+
+func pout(format string, a ...any) {
+	// TODO Make target configurable via root command-line flag
+	_, _ = fmt.Fprintf(os.Stdout, format, a...)
 }
 
 func humanReadableSize(bytes int64) string {

--- a/internal/cmd/image_repackage.go
+++ b/internal/cmd/image_repackage.go
@@ -51,7 +51,7 @@ var repackageCmd = &cobra.Command{
 			return err
 		}
 
-		if repackageCmdSettings.target.Tag.RegistryStr() == "" {
+		if repackageCmdSettings.target.RegistryStr() == "" {
 			defaultTag, err := name.NewTag(ref.String() + "-repackaged")
 			if err != nil {
 				return err

--- a/internal/cmd/image_repackage.go
+++ b/internal/cmd/image_repackage.go
@@ -24,7 +24,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -126,9 +125,9 @@ var repackageCmd = &cobra.Command{
 				return err
 			}
 
-			fmt.Fprintf(os.Stdout, "repackage plan (%d entries)\n", len(plan))
+			pout("repackage plan (%d entries)\n", len(plan))
 			for i := range plan {
-				fmt.Fprintf(os.Stdout, "  %s layer=%d (%s)\n",
+				pout("  %s layer=%d (%s)\n",
 					plan[i].Intent,
 					plan[i].OriginalIdx,
 					plan[i].History.CreatedBy,

--- a/pkg/interactive/edit.go
+++ b/pkg/interactive/edit.go
@@ -52,7 +52,6 @@ func Edit(input string) (output string, err error) {
 	// TODO Introduce {} style replacement option
 	args = append(args, filename)
 
-	fmt.Fprintf(os.Stderr, "Running: %s %v\n", editor, args)
 	var cmd = exec.Command(editor, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/repackage/errors.go
+++ b/pkg/repackage/errors.go
@@ -24,4 +24,4 @@ import "errors"
 
 // TODO Check wording
 
-var fixupOnEmptyLayer = errors.New("cannot use fixup for an empty layer")
+var errFixupOnEmptyLayer = errors.New("cannot use fixup for an empty layer")

--- a/pkg/repackage/repackage.go
+++ b/pkg/repackage/repackage.go
@@ -139,7 +139,7 @@ func Image(input v1.Image, plan Plan) (v1.Image, error) {
 		// TODO Write comment
 		case FIXUP:
 			if action.Layer == nil {
-				return nil, fixupOnEmptyLayer
+				return nil, errFixupOnEmptyLayer
 			}
 
 			if stage.directory == nil {

--- a/pkg/repackage/repackage_suite_test.go
+++ b/pkg/repackage/repackage_suite_test.go
@@ -23,6 +23,7 @@ package repackage_test
 import (
 	"bytes"
 	"fmt"
+	"math/rand/v2"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/gonvenience/ytbx"
 	"github.com/homeport/dyff/pkg/dyff"
-	"golang.org/x/exp/rand"
 	"gopkg.in/yaml.v3"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -49,7 +49,7 @@ func TestRepackage(t *testing.T) {
 func random(n int) string {
 	var buf = make([]rune, n)
 	for i := range buf {
-		buf[i] = lcs[rand.Intn(len(lcs))]
+		buf[i] = lcs[rand.IntN(len(lcs))]
 	}
 
 	return string(buf)

--- a/pkg/tar/create.go
+++ b/pkg/tar/create.go
@@ -37,8 +37,8 @@ func Create(directory string) (*os.File, error) {
 
 	tw := tar.NewWriter(target)
 	defer func() {
-		tw.Flush()
-		tw.Close()
+		_ = tw.Flush()
+		_ = tw.Close()
 	}()
 
 	return target, filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
@@ -106,7 +106,7 @@ func write(w io.Writer, path string) error {
 		return err
 	}
 
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	_, err = io.Copy(w, file)
 	return err

--- a/pkg/tar/extract.go
+++ b/pkg/tar/extract.go
@@ -36,7 +36,7 @@ func ExtractLayer(layer v1.Layer, dst string) error {
 		return err
 	}
 
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	return ExtractCompressed(rc, dst)
 }
 
@@ -45,7 +45,7 @@ func ExtractCompressed(r io.Reader, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer gzr.Close()
+	defer func() { _ = gzr.Close() }()
 
 	var tr = tar.NewReader(gzr)
 	for {
@@ -94,7 +94,9 @@ func ExtractCompressed(r io.Reader, dst string) error {
 
 			// manually close here after each file operation; defering would cause each file close
 			// to wait until all operations have completed.
-			f.Close()
+			if err := f.Close(); err != nil {
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Introduce helper output function
- Address `golangci-lint` findings
